### PR TITLE
fix: optimize reading byte-aligned types from a byte-aligned buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,10 @@ nsw-types = { version = "0.1.13", features = ["std", "bitvec"] }
 bitvec = "1.0.1"
 bytes = "1.10.1"
 funty = "2.0.0"
+
+[dev-dependencies]
+divan = "0.1.21"
+
+[[bench]]
+name = "put_get_ux"
+harness = false

--- a/benches/put_get_ux.rs
+++ b/benches/put_get_ux.rs
@@ -1,0 +1,24 @@
+use bits_io::prelude::*;
+
+fn main() {
+    // Run registered benchmarks.
+    divan::main();
+}
+
+#[divan::bench(sample_size = 10000)]
+fn get_ux_byte_aligned() {
+    let mut bits = Bits::from_static_bytes(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+    let _ = bits.get_u8();
+    let _ = bits.get_u16::<NetworkOrder>();
+    let _ = bits.get_u24::<NetworkOrder>();
+    let _ = bits.get_u32::<NetworkOrder>();
+}
+
+#[divan::bench(sample_size = 10000)]
+fn put_ux_byte_aligned() {
+    let mut bits_mut = BitsMut::new();
+
+    let _ = bits_mut.put_u24::<NetworkOrder>(u24::new(42));
+    let _ = bits_mut.put_u24::<NetworkOrder>(u24::new(42));
+}

--- a/src/buf/bit_buf_exts.rs
+++ b/src/buf/bit_buf_exts.rs
@@ -54,6 +54,19 @@ pub trait BitBufExts: BitBuf {
     }
 
     fn get_u8(&mut self) -> std::io::Result<u8> {
+        if self.byte_aligned() {
+            if self.remaining_bytes() < 1 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "Remaining bytes ({}) are less than the size of the dest (1)",
+                        self.remaining_bytes(),
+                    ),
+                ));
+            }
+            self.advance_bytes(1);
+            return Ok(self.chunk_bytes()[0]);
+        }
         self.get_uN::<BigEndian, 8, u8, u8>()
     }
 
@@ -79,6 +92,20 @@ pub trait BitBufExts: BitBuf {
         self.get_uN::<O, 15, u15, u16>()
     }
     fn get_u16<O: ByteOrder>(&mut self) -> std::io::Result<u16> {
+        if self.byte_aligned() {
+            if self.remaining_bytes() < 2 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "Remaining bytes ({}) are less than the size of the dest (2)",
+                        self.remaining_bytes(),
+                    ),
+                ));
+            }
+            let mut dest = [0u8; 2];
+            self.try_copy_to_slice_bytes(&mut dest)?;
+            return Ok(O::load_u16(&dest));
+        }
         self.get_uN::<O, 16, u16, u16>()
     }
     fn get_u17<O: ByteOrder>(&mut self) -> std::io::Result<u17> {
@@ -103,6 +130,20 @@ pub trait BitBufExts: BitBuf {
         self.get_uN::<O, 23, u23, u32>()
     }
     fn get_u24<O: ByteOrder>(&mut self) -> std::io::Result<u24> {
+        if self.byte_aligned() {
+            if self.remaining_bytes() < 3 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "Remaining bytes ({}) are less than the size of the dest (3)",
+                        self.remaining_bytes(),
+                    ),
+                ));
+            }
+            let mut dest = [0u8; 3];
+            self.try_copy_to_slice_bytes(&mut dest)?;
+            return Ok(O::load_u24(&dest));
+        }
         self.get_uN::<O, 24, u24, u32>()
     }
     fn get_u25<O: ByteOrder>(&mut self) -> std::io::Result<u25> {
@@ -127,6 +168,20 @@ pub trait BitBufExts: BitBuf {
         self.get_uN::<O, 31, u31, u32>()
     }
     fn get_u32<O: ByteOrder>(&mut self) -> std::io::Result<u32> {
+        if self.byte_aligned() {
+            if self.remaining_bytes() < 4 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "Remaining bytes ({}) are less than the size of the dest (4)",
+                        self.remaining_bytes(),
+                    ),
+                ));
+            }
+            let mut dest = [0u8; 4];
+            self.try_copy_to_slice_bytes(&mut dest)?;
+            return Ok(O::load_u32(&dest));
+        }
         self.get_uN::<O, 32, u32, u32>()
     }
 }

--- a/src/buf/bit_buf_mut.rs
+++ b/src/buf/bit_buf_mut.rs
@@ -151,7 +151,7 @@ pub trait BitBufMut {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
                 format!(
-                    "Remaining  bytes ({}) are less than the size of the source ({})",
+                    "Remaining bytes ({}) are less than the size of the source ({})",
                     self.remaining_mut_bytes(),
                     src.len()
                 ),

--- a/src/buf/byte_order.rs
+++ b/src/buf/byte_order.rs
@@ -8,7 +8,14 @@ use crate::prelude::*;
 /// Endian).
 pub trait ByteOrder {
     fn load<O: BitStore, U: Integral>(src: &BitSlice<O>) -> U;
+    fn load_u16(src: &[u8]) -> u16;
+    fn load_u24(src: &[u8]) -> u24;
+    fn load_u32(src: &[u8]) -> u32;
+
     fn store<O: BitStore, U: Integral>(dest: &mut BitSlice<O>, value: U);
+    fn store_u16(dest: &mut [u8], value: u16);
+    fn store_u24(dest: &mut [u8], value: u24);
+    fn store_u32(dest: &mut [u8], value: u32);
 }
 
 pub struct BigEndian {}
@@ -22,8 +29,46 @@ impl ByteOrder for BigEndian {
         src.load_be()
     }
 
+    fn load_u16(src: &[u8]) -> u16 {
+        u16::from_be_bytes(src.try_into().unwrap())
+    }
+
+    fn load_u24(src: &[u8]) -> u24 {
+        let mut value = 0u32;
+        value |= src[0] as u32;
+        value <<= 8;
+        value |= src[1] as u32;
+        value <<= 8;
+        value |= src[2] as u32;
+
+        u24::new(value)
+    }
+
+    fn load_u32(src: &[u8]) -> u32 {
+        u32::from_be_bytes(src.try_into().unwrap())
+    }
+
     fn store<O: BitStore, U: Integral>(dest: &mut BitSlice<O>, value: U) {
         dest.store_be(value);
+    }
+
+    fn store_u16(dest: &mut [u8], value: u16) {
+        dest[0] = (value >> 8) as u8;
+        dest[1] = value as u8;
+    }
+
+    fn store_u24(dest: &mut [u8], value: u24) {
+        let value: u32 = value.into();
+        dest[0] = (value >> 16) as u8;
+        dest[1] = (value >> 8) as u8;
+        dest[2] = value as u8;
+    }
+
+    fn store_u32(dest: &mut [u8], value: u32) {
+        dest[0] = (value >> 24) as u8;
+        dest[1] = (value >> 16) as u8;
+        dest[2] = (value >> 8) as u8;
+        dest[3] = value as u8;
     }
 }
 
@@ -32,8 +77,45 @@ impl ByteOrder for LittleEndian {
         src.load_le()
     }
 
+    fn load_u16(src: &[u8]) -> u16 {
+        u16::from_le_bytes(src.try_into().unwrap())
+    }
+
+    fn load_u24(src: &[u8]) -> u24 {
+        let mut value = 0u32;
+        value |= src[2] as u32;
+        value <<= 8;
+        value |= src[1] as u32;
+        value <<= 8;
+        value |= src[0] as u32;
+        u24::new(value)
+    }
+
+    fn load_u32(src: &[u8]) -> u32 {
+        u32::from_le_bytes(src.try_into().unwrap())
+    }
+
     fn store<O: BitStore, U: Integral>(dest: &mut BitSlice<O>, value: U) {
         dest.store_le(value)
+    }
+
+    fn store_u16(dest: &mut [u8], value: u16) {
+        dest[0] = value as u8;
+        dest[1] = (value >> 8) as u8;
+    }
+
+    fn store_u24(dest: &mut [u8], value: u24) {
+        let value: u32 = value.into();
+        dest[0] = value as u8;
+        dest[1] = (value >> 8) as u8;
+        dest[2] = (value >> 16) as u8;
+    }
+
+    fn store_u32(dest: &mut [u8], value: u32) {
+        dest[0] = value as u8;
+        dest[1] = (value >> 8) as u8;
+        dest[2] = (value >> 16) as u8;
+        dest[3] = (value >> 24) as u8;
     }
 }
 


### PR DESCRIPTION
This change optimizes reading and writing byte-aligned values (u8, u16, u24, u32) when the buffer is byte-aligned as well.  

bench before:

```
Timer precision: 36 ns
put_get_ux              fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ get_ux_byte_aligned  276 ns        │ 382.6 ns      │ 307.7 ns      │ 311.8 ns      │ 100     │ 1000000
╰─ put_ux_byte_aligned  174.9 ns      │ 224.7 ns      │ 185.5 ns      │ 188.2 ns      │ 100     │ 1000000
```


after:

```
Timer precision: 43 ns
put_get_ux              fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ get_ux_byte_aligned  67.45 ns      │ 96.33 ns      │ 76.11 ns      │ 76.61 ns      │ 100     │ 1000000
╰─ put_ux_byte_aligned  69.12 ns      │ 98.73 ns      │ 76.47 ns      │ 77.76 ns      │ 100     │ 1000000
```

Note that even though we check for byte alignment, due to `chain` we can't assume the bytes we're writing to are contiguous, so even with this change we have copy the data into bytes and then write them via `try_copy_to_slice_bytes`/`try_put_slice_bytes` so the reads/writes will play nicely if the underlying buffer is chained.