### PR TITLE
fix: optimize unalighed bit reads and writes

### DIFF
--- a/benches/put_get_ux.rs
+++ b/benches/put_get_ux.rs
@@ -16,9 +16,31 @@ fn get_ux_byte_aligned() {
 }
 
 #[divan::bench(sample_size = 10000)]
+fn get_ux_unaligned() {
+    let mut bits = Bits::from_static_bytes(&[0, 1, 2, 3, 4]);
+
+    let _ = bits.get_u3();
+    let _ = bits.get_u6();
+    let _ = bits.get_u9::<NetworkOrder>();
+    let _ = bits.get_u12::<NetworkOrder>();
+}
+
+#[divan::bench(sample_size = 10000)]
 fn put_ux_byte_aligned() {
     let mut bits_mut = BitsMut::new();
 
-    let _ = bits_mut.put_u24::<NetworkOrder>(u24::new(42));
-    let _ = bits_mut.put_u24::<NetworkOrder>(u24::new(42));
+    let _ = bits_mut.put_u8(2);
+    let _ = bits_mut.put_u16::<NetworkOrder>(4);
+    let _ = bits_mut.put_u24::<NetworkOrder>(u24::new(6));
+    let _ = bits_mut.put_u32::<NetworkOrder>(8);
+}
+
+#[divan::bench(sample_size = 10000)]
+fn put_ux_unaligned() {
+    let mut bits_mut = BitsMut::new();
+
+    let _ = bits_mut.put_u3(u3::new(2));
+    let _ = bits_mut.put_u6(u6::new(4));
+    let _ = bits_mut.put_u9::<NetworkOrder>(u9::new(6));
+    let _ = bits_mut.put_u12::<NetworkOrder>(u12::new(8));
 }

--- a/src/buf/bit_buf_exts.rs
+++ b/src/buf/bit_buf_exts.rs
@@ -10,15 +10,25 @@ pub trait BitBufExts: BitBuf {
         U: TryFrom<V>,
         U::Error: std::fmt::Debug,
     {
-        // Create a bitvec in which to load the value
-        let mut bits = BitVec::repeat(false, N);
-        let slice = bits.as_mut_bitslice();
-        // Copy the raw bits into the slice
-        self.try_copy_to_bit_slice(slice)?;
-        // Now 'load' the value from that slice according to the given ByteOrder.
-        let value: V = O::load(slice);
+        // If this buffer is chained to another there may be enough room to read the value but it
+        // may not be continuguous.  If it is, then we can read directly instead of copying to an
+        // intermediary first.
+        let slice = self.chunk_bits();
+        if slice.len() >= N {
+            let value: V = O::load(&slice[..N]);
+            self.advance_bits(N);
 
-        Ok(U::try_from(value).map_err(|_| std::io::ErrorKind::InvalidData)?)
+            Ok(U::try_from(value).map_err(|_| std::io::ErrorKind::InvalidData)?)
+        } else {
+            let mut bits = BitVec::repeat(false, N);
+            let slice = bits.as_mut_bitslice();
+            // Copy the raw bits into the slice
+            self.try_copy_to_bit_slice(slice)?;
+            // Now 'load' the value from that slice according to the given ByteOrder.
+            let value: V = O::load(slice);
+
+            Ok(U::try_from(value).map_err(|_| std::io::ErrorKind::InvalidData)?)
+        }
     }
 
     fn get_bool(&mut self) -> std::io::Result<bool> {

--- a/src/buf/bit_buf_exts.rs
+++ b/src/buf/bit_buf_exts.rs
@@ -11,7 +11,7 @@ pub trait BitBufExts: BitBuf {
         U::Error: std::fmt::Debug,
     {
         // If this buffer is chained to another there may be enough room to read the value but it
-        // may not be continuguous.  If it is, then we can read directly instead of copying to an
+        // may not be contiguous.  If it is, then we can read directly instead of copying to an
         // intermediary first.
         let slice = self.chunk_bits();
         if slice.len() >= N {

--- a/src/buf/bit_buf_mut_exts.rs
+++ b/src/buf/bit_buf_mut_exts.rs
@@ -16,7 +16,7 @@ pub trait BitBufMutExts: BitBufMut {
         let value_integral: V = value.into();
         let slice = self.chunk_mut_bits();
         // If this buffer is chained to another we may have enough space to store the value but it
-        // may not be continuguous.  If it is, then we can write directly into the slice instead of
+        // may not be contiguous.  If it is, then we can write directly into the slice instead of
         // copying to an intermediary first
         if slice.len() >= N {
             O::store(&mut slice[..N], value_integral);

--- a/src/buf/bit_buf_mut_exts.rs
+++ b/src/buf/bit_buf_mut_exts.rs
@@ -14,12 +14,21 @@ pub trait BitBufMutExts: BitBufMut {
         // Convert the given value into the given integral type we're told it should map to (V).
         // E.g. u8, u16, u32.
         let value_integral: V = value.into();
-
-        let mut bits = BitVec::repeat(false, N);
-        let value_slice = bits.as_mut_bitslice();
-        O::store(value_slice, value_integral);
-        self.try_put_bit_slice(value_slice)?;
-        Ok(())
+        let slice = self.chunk_mut_bits();
+        // If this buffer is chained to another we may have enough space to store the value but it
+        // may not be continuguous.  If it is, then we can write directly into the slice instead of
+        // copying to an intermediary first
+        if slice.len() >= N {
+            O::store(&mut slice[..N], value_integral);
+            self.advance_mut_bits(N);
+            Ok(())
+        } else {
+            let mut bits = BitVec::repeat(false, N);
+            let value_slice = bits.as_mut_bitslice();
+            O::store(value_slice, value_integral);
+            self.try_put_bit_slice(value_slice)?;
+            Ok(())
+        }
     }
 
     fn put_bool(&mut self, value: bool) -> std::io::Result<()> {


### PR DESCRIPTION
The copying to/from slices was noticeably showing up in flamegraphs so took a shot at optimizing those and these changes seem to make a pretty good impact.  Due to the possibility of buffers being chained together, we can only do the optimization when there's enough contiguous storage but that is usually going to be the case.



before:

```
Timer precision: 50 ns
put_get_ux              fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ get_ux_byte_aligned  64.81 ns      │ 94.05 ns      │ 71.41 ns      │ 73.36 ns      │ 100     │ 1000000
├─ get_ux_unaligned     306.3 ns      │ 477 ns        │ 341.5 ns      │ 357 ns        │ 100     │ 1000000
├─ put_ux_byte_aligned  119.1 ns      │ 159.5 ns      │ 127.5 ns      │ 129.7 ns      │ 100     │ 1000000
╰─ put_ux_unaligned     335 ns        │ 432.3 ns      │ 352.9 ns      │ 361.8 ns      │ 100     │ 1000000
```

after:

```
Timer precision: 39 ns
put_get_ux              fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ get_ux_byte_aligned  68.62 ns      │ 110.8 ns      │ 77.04 ns      │ 78.86 ns      │ 100     │ 1000000
├─ get_ux_unaligned     92.38 ns      │ 128 ns        │ 103.2 ns      │ 105.9 ns      │ 100     │ 1000000
├─ put_ux_byte_aligned  123.5 ns      │ 169.7 ns      │ 133.9 ns      │ 135.2 ns      │ 100     │ 1000000
╰─ put_ux_unaligned     129.2 ns      │ 178.6 ns      │ 145.6 ns      │ 146.4 ns      │ 100     │ 1000000
```